### PR TITLE
Fix Docker build failing due to missing dom extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ WORKDIR /app
 COPY . .
 WORKDIR /app/laravel-api
 RUN apt-get update \
-    && apt-get install -y libzip-dev unzip sqlite3 libsqlite3-dev \
-    && docker-php-ext-install pdo pdo_sqlite
+    && apt-get install -y libzip-dev unzip sqlite3 libsqlite3-dev libxml2-dev \
+    && docker-php-ext-install pdo pdo_sqlite dom
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN composer install --no-dev --prefer-dist --no-interaction \
+RUN composer install --prefer-dist --no-interaction \
     && cp .env.example .env \
     && php artisan key:generate \
     && touch database/database.sqlite \

--- a/laravel-api/Dockerfile
+++ b/laravel-api/Dockerfile
@@ -2,10 +2,10 @@ FROM php:8.3-cli
 WORKDIR /app
 COPY . .
 RUN apt-get update \
-    && apt-get install -y libzip-dev unzip sqlite3 libsqlite3-dev \
-    && docker-php-ext-install pdo pdo_sqlite
+    && apt-get install -y libzip-dev unzip sqlite3 libsqlite3-dev libxml2-dev \
+    && docker-php-ext-install pdo pdo_sqlite dom
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN composer install --no-dev --prefer-dist --no-interaction \
+RUN composer install --prefer-dist --no-interaction \
     && cp .env.example .env \
     && php artisan key:generate \
     && touch database/database.sqlite \


### PR DESCRIPTION
## Summary
- install `libxml2-dev` so PHP's `dom` extension can be enabled
- enable the `dom` extension during build
- include dev dependencies when running Composer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867d0b1fa088328ab3b67c0165750cc